### PR TITLE
Add git to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ LABEL maintainer Mofesola Babalola <me@mofesola.com>
 #Get required applications
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN apt-get update && apt-get install -y git
+
 #Create App Directory
 WORKDIR /usr/src/app
 
 #Install Dependencies
 COPY package.json /usr/src/app
-RUN apt-get update && apt-get install -y git
 RUN npm install --loglevel silent
 
 COPY . /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:boron-slim
+FROM node:boron
 LABEL maintainer Mofesola Babalola <me@mofesola.com>
 
 #Get required applications

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:boron
+FROM node:boron-slim
 LABEL maintainer Mofesola Babalola <me@mofesola.com>
 
 #Get required applications
@@ -9,6 +9,7 @@ WORKDIR /usr/src/app
 
 #Install Dependencies
 COPY package.json /usr/src/app
+RUN apt-get update && apt-get install -y git
 RUN npm install --loglevel silent
 
 COPY . /usr/src/app


### PR DESCRIPTION
Use a node image that includes git for fetching npm dependencies. This is needed when our dependencies use "github:..." instead of a version number in package.json.

Fixes #89.