### PR TITLE
Docker fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     container_name: elasticsearch_hr
     image: docker.elastic.co/elasticsearch/elasticsearch:5.3.1
     volumes:
-      - ./data/elasticsearch:/usr/share/elasticsearch/data
+      - esdata1:/usr/share/elasticsearch/data
     ports:
       - "9201:9200"
     environment:
@@ -71,3 +71,7 @@ services:
     links:
       - couchdb
       - elasticsearch
+
+volumes:
+  esdata1:
+    driver: local

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -17,7 +17,7 @@ COPY conf/defaultssl.conf.tmpl /etc/nginx/conf.d/defaultssl.conf.tmpl
 COPY conf/entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 RUN envsubst < /etc/nginx/conf.d/default.conf.tmpl > /etc/nginx/conf.d/default.conf \
-        && envsubst < /etc/nginx/conf.d/defaultssl.conf.tmpl > /etc/nginx/conf.d/defaultssl.conf
+        && envsubst < /etc/nginx/conf.d/defaultssl.conf.tmpl > /etc/nginx/conf.d/defaultssl
 
 ENTRYPOINT /etc/nginx/entrypoint.sh
 EXPOSE 80 443

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "license": "GPL-3.0",
   "dependencies": {
     "colors": "^1.1.2",
-    "csv-parse": "2.2.0",
-    "csv-stringify": "^3.0.0",
+    "csv-parse": "2.0.2",
+    "csv-stringify": "^2.0.0",
     "express": "^4.13.4",
     "hospitalrun": "1.0.0-beta",
     "hospitalrun-dblisteners": "1.0.0-beta",
@@ -30,7 +30,7 @@
     "morgan": "^1.6.1",
     "nano": "^6.2.0",
     "node-uuid": "^1.4.2",
-    "osprey": "^0.5.0",
+    "osprey": "^0.4.1",
     "prompt": "^1.0.0",
     "snyk": "^1.17.5"
   },


### PR DESCRIPTION
Fixes #98, #87, #78.
Addresses #96.

Apparently docker didn't like this `osprey` update. I rolled the recent updates back. I rolled back some more package updates because I am not sure that they didn't cause any more issues.
I also fixed the elastic search.  