### PR TITLE
Change http port and offer non-automatic SSL option.

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -62,9 +62,9 @@ Follow these five easy steps to get HospitalRun up and running
 
    To use automatic SSL cert generation, edit the `DOMAIN_NAME` argument and replace `www.example.com` as shown in the image below with the publicly accessible domain name that HospitalRun will run on.
 
-   To instead use your own SSL cert, change the `ENCRYPTION_TYPE` argument to `self` and place your certificate files at `data/nginx/cert/ssl.crt` and `data/nginx/cert/ssl.key`. You will need to create a `data/nginx/cert` path from the root folder if you haven't run the server yet.
+   To instead use your own SSL cert, change the `SSL_TYPE` argument to `self` and place your certificate files at `data/nginx/cert/ssl.crt` and `data/nginx/cert/ssl.key`. You will need to create a `data/nginx/cert` path from the root folder if you haven't run the server yet.
   
-   To use no SSL cert, change the `ENCRYPTION_TYPE` argument to `none`, but your server will only be accessible locally.
+   To use no SSL cert, change the `SSL_TYPE` argument to `none`, but your server will only be accessible locally.
 
 4. Save the file and run `docker-compose up --build -d`. You should wait for some ten minutes or less for your environment to be up and running. Deployment speed will vary based on your internet connection speed and the quality of your infrastructure
 

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -58,11 +58,17 @@ Follow these five easy steps to get HospitalRun up and running
 
 2. Run `cd hospitalrun-server`. This should take you into the `hospitalrun-server` root folder
 
-3. From this location, edit the `docker-compose.yml` file. Within the nginx service, edit the `DOMAIN_NAME` argument and replace `www.example.com` as shown in the image below with the  publicly accessible domain name that HospitalRun will run on
+3. From this location, edit the `docker-compose.yml` file.
+
+   To use automatic SSL cert generation, edit the `DOMAIN_NAME` argument and replace `www.example.com` as shown in the image below with the publicly accessible domain name that HospitalRun will run on.
+
+   To instead use your own SSL cert, change the `ENCRYPTION_TYPE` argument to `self` and place your certificate files at `data/nginx/cert/ssl.crt` and `data/nginx/cert/ssl.key`. You will need to create a `data/nginx/cert` path from the root folder if you haven't run the server yet.
+  
+   To use no SSL cert, change the `ENCRYPTION_TYPE` argument to `none`, but your server will only be accessible locally.
 
 4. Save the file and run `docker-compose up --build -d`. You should wait for some ten minutes or less for your environment to be up and running. Deployment speed will vary based on your internet connection speed and the quality of your infrastructure
 
-5. Go to [http://localhost:8055/](http://localhost:8055/) in a browser and login with username ```hradmin``` and password ```test```
+5. Go to [http://localhost/](http://localhost/) in a browser and login with username ```hradmin``` and password ```test```
 
 ![screenshot](screenshot.png)
 

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -63,8 +63,6 @@ Follow these five easy steps to get HospitalRun up and running
    To use automatic SSL cert generation, edit the `DOMAIN_NAME` argument and replace `www.example.com` as shown in the image below with the publicly accessible domain name that HospitalRun will run on.
 
    To instead use your own SSL cert, change the `SSL_TYPE` argument to `self` and place your certificate files at `data/nginx/cert/ssl.crt` and `data/nginx/cert/ssl.key`. You will need to create a `data/nginx/cert` path from the root folder if you haven't run the server yet.
-  
-   To use no SSL cert, change the `SSL_TYPE` argument to `none`, but your server will only be accessible locally.
 
 4. Save the file and run `docker-compose up --build -d`. You should wait for some ten minutes or less for your environment to be up and running. Deployment speed will vary based on your internet connection speed and the quality of your infrastructure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       args:
         DOMAIN_NAME: www.example.com
-        ENCRYPTION_TYPE: auto
+        SSL_TYPE: auto
       context: nginx/.
       dockerfile: Dockerfile
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,18 @@ services:
     build:
       args:
         DOMAIN_NAME: www.example.com
+        ENCRYPTION_TYPE: auto
       context: nginx/.
       dockerfile: Dockerfile
     links:
       - hospitalrun
     ports:
-      - "8055:80"
+      - "80:80"
       - "443:443"
     image: hospitalrun_nginx
     volumes:
       - ./data/nginx/letsencrypt:/etc/letsencrypt
+      - ./data/nginx/cert:/etc/nginx/cert
 
   hospitalrun:
     container_name: hospitalrun

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:1.11.10
 LABEL Maintainer Mofesola Babalola <me@mofesola.com>
 
 ARG DOMAIN_NAME
-ARG ENCRYPTION_TYPE
+ARG SSL_TYPE
 
 RUN apt-get -y update && apt-get install -y cron
 
@@ -10,7 +10,7 @@ COPY conf/certbot-auto /usr/bin/
 RUN  certbot-auto --os-packages-only --non-interactive
 
 ENV DOMAIN_NAME $DOMAIN_NAME
-ENV ENCRYPTION_TYPE $ENCRYPTION_TYPE
+ENV SSL_TYPE $SSL_TYPE
 
 WORKDIR /etc/nginx
 COPY conf/nginx.conf /etc/nginx/nginx.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,6 +2,7 @@ FROM nginx:1.11.10
 LABEL Maintainer Mofesola Babalola <me@mofesola.com>
 
 ARG DOMAIN_NAME
+ARG ENCRYPTION_TYPE
 
 RUN apt-get -y update && apt-get install -y cron
 
@@ -9,15 +10,19 @@ COPY conf/certbot-auto /usr/bin/
 RUN  certbot-auto --os-packages-only --non-interactive
 
 ENV DOMAIN_NAME $DOMAIN_NAME
+ENV ENCRYPTION_TYPE $ENCRYPTION_TYPE
 
 WORKDIR /etc/nginx
 COPY conf/nginx.conf /etc/nginx/nginx.conf
-COPY conf/default.conf.tmpl /etc/nginx/conf.d/default.conf.tmpl
-COPY conf/defaultssl.conf.tmpl /etc/nginx/conf.d/defaultssl.conf.tmpl
+
+COPY conf/default.conf.tmpl /etc/nginx/conf.d/default
+COPY conf/defaultautossl.conf.tmpl /etc/nginx/conf.d/defaultautossl.tmpl
+COPY conf/defaultselfssl.conf.tmpl /etc/nginx/conf.d/defaultselfssl
+
 COPY conf/entrypoint.sh entrypoint.sh
+
 RUN chmod +x entrypoint.sh
-RUN envsubst < /etc/nginx/conf.d/default.conf.tmpl > /etc/nginx/conf.d/default.conf \
-        && envsubst < /etc/nginx/conf.d/defaultssl.conf.tmpl > /etc/nginx/conf.d/defaultssl
+RUN envsubst < /etc/nginx/conf.d/defaultautossl.tmpl > /etc/nginx/conf.d/defaultautossl
 
 ENTRYPOINT /etc/nginx/entrypoint.sh
 EXPOSE 80 443

--- a/nginx/conf/defaultautossl.conf.tmpl
+++ b/nginx/conf/defaultautossl.conf.tmpl
@@ -26,13 +26,37 @@ server {
 
     #charset koi8-r;
     access_log /dev/stdout;
-    error_log /dev/stderr info;
+    error_log /dev/stderr debug;
+
+
+    location / {
+             proxy_pass http://hospitalrun:3000;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+    location ~ /\.ht {
+        deny  all;
+    }
+}
+
+server {
+    listen       443 ssl;
+    server_name  _;
+
+    #charset koi8-r;
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
 
 
     location / {
 
-             proxy_pass http://hospitalrun:3000;
+        proxy_pass http://hospitalrun:3000;
 
+        # Add HTTP Strict Transport Security for good measure.
+           add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
     }
 
     error_page   500 502 503 504  /50x.html;
@@ -44,4 +68,6 @@ server {
     }
 
 
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem;
 }

--- a/nginx/conf/defaultselfssl.conf.tmpl
+++ b/nginx/conf/defaultselfssl.conf.tmpl
@@ -67,7 +67,6 @@ server {
         deny  all;
     }
 
-
-  ssl_certificate /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem;
+    ssl_certificate /etc/nginx/cert/ssl.crt;
+    ssl_certificate_key /etc/nginx/cert/ssl.key;
 }

--- a/nginx/conf/entrypoint.sh
+++ b/nginx/conf/entrypoint.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 rm /etc/nginx/conf.d/*.conf
-if [ "$ENCRYPTION_TYPE" = "auto" ]; then
+if [ "$SSL_TYPE" = "auto" ]; then
 	if [ ! -f /etc/letsencrypt/live/${DOMAIN_NAME}/cert.pem ]; then
 		mkdir -p /var/log/letsencrypt && touch /var/log/letsencrypt/install.log \
 		&& certbot-auto certonly --standalone --non-interactive --agree-tos --email admin@${DOMAIN_NAME} -d ${DOMAIN_NAME} 2>&1 | tee /var/log/letsencrypt/install.log
 	fi \
 	&& (crontab -l 2>/dev/null; echo "30 2 * * 1 /usr/bin/certbot-auto renew --quiet --no-self-upgrade >> /var/log/letsencrypt/le-renew.log") | crontab - \
 	&& cp /etc/nginx/conf.d/defaultautossl /etc/nginx/conf.d/defaultautossl.conf
-elif [ "$ENCRYPTION_TYPE" = "self" ]; then
+elif [ "$SSL_TYPE" = "self" ]; then
     	cp /etc/nginx/conf.d/defaultselfssl /etc/nginx/conf.d/defaultselfssl.conf
-elif [ "$ENCRYPTION_TYPE" = "none" ]; then
+elif [ "$SSL_TYPE" = "none" ]; then
    	cp /etc/nginx/conf.d/default /etc/nginx/conf.d/default.conf
 fi
 nginx -g "daemon off;"

--- a/nginx/conf/entrypoint.sh
+++ b/nginx/conf/entrypoint.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-(crontab -l 2>/dev/null; echo "30 2 * * 1 /usr/bin/certbot-auto renew --quiet --no-self-upgrade >> /var/log/letsencrypt/le-renew.log") | crontab -
-mkdir -p /var/log/letsencrypt && touch /var/log/letsencrypt/install.log
-if [ ! -f /etc/letsencrypt/live/${DOMAIN_NAME}/cert.pem ]; then
-    certbot-auto certonly --standalone --non-interactive --agree-tos --email admin@${DOMAIN_NAME} -d ${DOMAIN_NAME} 2>&1 | tee /var/log/letsencrypt/install.log \
-               && if [ -f /etc/letsencrypt/live/${DOMAIN_NAME}/cert.pem ]; then
-                       mv /etc/nginx/conf.d/defaultssl /etc/nginx/conf.d/defaultssl.conf \
-                    && rm /etc/nginx/conf.d/default.conf  \
-                    && nginx -s reload
-                  fi \
-               &
+rm /etc/nginx/conf.d/*.conf
+if [ "$ENCRYPTION_TYPE" = "auto" ]; then
+	if [ ! -f /etc/letsencrypt/live/${DOMAIN_NAME}/cert.pem ]; then
+		mkdir -p /var/log/letsencrypt && touch /var/log/letsencrypt/install.log \
+		&& certbot-auto certonly --standalone --non-interactive --agree-tos --email admin@${DOMAIN_NAME} -d ${DOMAIN_NAME} 2>&1 | tee /var/log/letsencrypt/install.log
+	fi \
+	&& (crontab -l 2>/dev/null; echo "30 2 * * 1 /usr/bin/certbot-auto renew --quiet --no-self-upgrade >> /var/log/letsencrypt/le-renew.log") | crontab - \
+	&& cp /etc/nginx/conf.d/defaultautossl /etc/nginx/conf.d/defaultautossl.conf
+elif [ "$ENCRYPTION_TYPE" = "self" ]; then
+    	cp /etc/nginx/conf.d/defaultselfssl /etc/nginx/conf.d/defaultselfssl.conf
+elif [ "$ENCRYPTION_TYPE" = "none" ]; then
+   	cp /etc/nginx/conf.d/default /etc/nginx/conf.d/default.conf
 fi
 nginx -g "daemon off;"


### PR DESCRIPTION
1) Some users have had issues with automatic SSL cert generation failing. We use certbot/letsencrypt in the "standalone" mode to get certs (https://www.digitalocean.com/community/tutorials/how-to-use-certbot-standalone-mode-to-retrieve-let-s-encrypt-ssl-certificates), which validates the cert by accessing your server on either port 443 or 80.

   The ability to use 443 was recently removed due to a security issue: https://community.letsencrypt.org/t/important-what-you-need-to-know-about-tls-sni-validation-issues/50811. Port 80 doesn't work for us either because we are currently exposing the nginx container's port 80 as port 8055 on the host, therefore cert cannot be generated.

2) Also, some users don't have their server on a publicly accessible domain but would still like to use the docker install.


This PR changes the port for http from 8055 back to 80, which makes certbot/letsencrypt work again (tested on my VPS). The nginx config is already set up to redirect all traffic on 80 to https, except for traffic coming from localhost. I'd still like somebody else to review the nginx config and see if there's any security implication since it's now more likely http will be exposed, but it seemed OK to me.

This PR also provides an option via a switch in docker-compose.yml for providing your own SSL cert in a docker attached volume instead of using automatic cert generation. I also provided an option "none" for no SSL cert which only allows access from localhost but could be useful for evaluation / testing / etc, but I'm undecided on whether that's ultimately useful or should be left out.